### PR TITLE
Postprocessing and multi channel outputs

### DIFF
--- a/experiments/syn_cremi/complete_inference.py
+++ b/experiments/syn_cremi/complete_inference.py
@@ -1,0 +1,67 @@
+from __future__ import  print_function
+import sys
+import os
+from concurrent.futures import ProcessPoolExecutor
+from subprocess import call
+
+sys.path.append('/groups/saalfeld/home/heinrichl/Projects/simpleference')
+from simpleference.inference.util import get_offset_lists
+import z5py
+
+
+def single_inference(sample, gpu, iteration):
+    call(['./run_inference.sh', sample, str(gpu), str(iteration)])
+    return True
+
+
+def complete_inference(sample, gpu_list, iteration):
+    # path to the raw data
+    raw_path = '/groups/saalfeld/saalfeldlab/larissa/data/cremi/cremi_warped_sample{0:}.n5/volumes/'.format(sample)
+    assert os.path.exists(raw_path), "Path to N5 dataset with raw data and mask does not exist"
+    rf = z5py.File(raw_path, use_zarr_format=False)
+    shape = rf['raw'].shape
+
+    # create the datasets
+    out_shape = (71, 650, 650)
+    out_file = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/'
+    if not os.path.exists(out_file):
+        os.mkdir(out_file)
+    out_file = os.path.join(out_file,
+                            'prediction_cremi_warped_sample{0:}_{1:}.n5'.format(sample, iteration))
+
+    f = z5py.File(out_file, use_zarr_format=False)
+    f.create_dataset('syncleft_dist',
+                     shape=shape,
+                     compressor='gzip',
+                     dtype='float32',
+                     chunks=out_shape)
+    f.create_dataset('syncleft_cc',
+                     shape=shape,
+                     compressor='gzip',
+                     dtype='uint64',
+                     chunks=out_shape)
+
+    # make the offset files, that assign blocks to gpus
+    offset_folder = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/offsets_{0:}_{1:}_x{2:}_y{3:}_z{4:}/'.format(
+        sample, iteration, out_shape[0], out_shape[1], out_shape[2])
+    if not os.path.exists(offset_folder):
+        os.mkdir(offset_folder)
+
+    get_offset_lists(shape, gpu_list, offset_folder, output_shape=out_shape)
+
+    # run multiprocessed inference
+    with ProcessPoolExecutor(max_workers=len(gpu_list)) as pp:
+        tasks = [pp.submit(single_inference, sample, gpu, iteration) for gpu in gpu_list]
+        result = [t.result() for t in tasks]
+
+    if all(result):
+        print("All gpu's finished inference properly.")
+    else:
+        print("WARNING: at least one process didn't finish properly.")
+
+
+if __name__ == '__main__':
+    gpu_list = list(range(8))
+    iteration = 448000
+    for sample in ["A+", "B+", "C+"]:
+        complete_inference(sample, gpu_list, iteration)

--- a/experiments/syn_cremi/run_inference.py
+++ b/experiments/syn_cremi/run_inference.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import time
+import json
+from functools import partial
+from simpleference.inference.inference import run_inference_n5
+from simpleference.backends.gunpowder.tensorflow.backend import TensorflowPredict
+from simpleference.backends.gunpowder.preprocess import preprocess
+from simpleference.backends.gunpowder.postprocess import threshold_cc
+
+
+def single_gpu_inference(sample, gpu, iteration):
+    raw_path = '/groups/saalfeld/saalfeldlab/larissa/data/cremi/cremi_warped_sample{0:}.n5/volumes'.format(sample)
+    assert os.path.exists(raw_path), "Path to N5 dataset with raw data and mask does not exist"
+
+    weight_meta_graph = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/unet_checkpoint_{0:}'.format(iteration)
+    inference_meta_graph = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/unet_inference'
+    net_io_json = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/net_io_names.json'
+
+    out_file = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/'
+    out_file = os.path.join(out_file, 'prediction_cremi_warped_sample{0:}_{1:}.n5'.format(sample, iteration))
+    assert os.path.exists(out_file)
+
+    with open(net_io_json, 'r') as f:
+        net_io_names = json.load(f)
+
+    input_key = net_io_names["raw"]
+    output_key = net_io_names["dist"]
+    input_shape = (91, 862, 862)
+    output_shape = (71, 650, 650)
+
+    offset_file = '/nrs/saalfeld/heinrichl/synapses/cremi_all_0116_01/' \
+                  'offsets_{0:}_{1:}_x{2:}_y{3:}_z{4:}/list_gpu_{5:}.json'.format(sample, iteration, output_shape[0],
+                                                                             output_shape[1], output_shape[2], gpu)
+    with open(offset_file, 'r') as f:
+        offset_list = json.load(f)
+    prediction = TensorflowPredict(weight_meta_graph, inference_meta_graph, input_key=input_key, output_key=output_key)
+
+    t_predict = time.time()
+    run_inference_n5(prediction,
+                     preprocess,
+                     partial(threshold_cc, thr=0.15),
+                     raw_path,
+                     out_file,
+                     offset_list,
+                     input_key='raw',
+                     input_shape=input_shape,
+                     output_shape=output_shape,
+                     target_keys=('syncleft_dist', 'syncleft_cc'),
+                     log_processed=os.path.join(os.path.dirname(offset_file),
+                                                'list_gpu_{0:}_processed.txt'.format(gpu))
+                     )
+
+    t_predict = time.time() - t_predict
+
+    with open(os.path.join(os.path.dirname(offset_file), 't-inf_gpu{0:}.txt'.format(gpu)), 'w') as f:
+        f.write("Inference with gpu {0:} in {1:} s\n".format(gpu, t_predict))
+
+
+if __name__ == '__main__':
+    sample = sys.argv[1]
+    gpu = int(sys.argv[2])
+    iteration = int(sys.argv[3])
+    single_gpu_inference(sample, gpu, iteration)

--- a/experiments/syn_cremi/run_inference.sh
+++ b/experiments/syn_cremi/run_inference.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Inputs:
+# Path - Path to the N5 dataset with raw data and mask
+# GPU - id of the gpu used for inference
+# Iteration - iteration of the network used
+
+export NAME=$(basename $PWD-prediction-$2)
+export USER_ID=${UID}
+GUNPOWDER_PATH=$(readlink -f $HOME/Projects/mygunpowder/gunpowder)
+SIMPLEFERENCE_PATH=$(readlink -f $HOME/Projects/simpleference)
+PRED_PATH=$(readlink -f $HOME/Projects/simpleference/experiments/syn_cremi)
+Z_PATH=$(readlink -f $HOME/../papec/Work/my_projects/z5/bld27/python)
+
+nvidia-docker rm -f $NAME
+
+nvidia-docker run --rm \
+    -u `id -u $USER` \
+    -v $(pwd):/workspace \
+    -v /groups/saalfeld:/groups/saalfeld \
+    -v /nrs/saalfeld/:/nrs/saalfeld \
+    -w /workspace \
+    --name $NAME \
+    neptunes5thmoon/gunpowder:v0.3-pre6-dask1 \
+    /bin/bash -c "export CUDA_VISIBLE_DEVICES=$2;
+    export PYTHONPATH=${GUNPOWDER_PATH}:${SIMPLEFERENCE_PATH}:${Z_PATH}:\$PYTHONPATH;
+    python -u ${PRED_PATH}/run_inference.py $1 $2 $3"

--- a/simpleference/backends/gunpowder/postprocess.py
+++ b/simpleference/backends/gunpowder/postprocess.py
@@ -1,0 +1,17 @@
+import numpy as np
+import scipy.ndimage
+
+
+def threshold_cc(data, thr=0.):
+    if not isinstance(data, np.ndarray):
+        data = np.array(data)
+    output = (data > thr).astype(np.uint64)
+    scipy.ndimage.label(output, output=output)
+    return [data.squeeze(), output.squeeze()]
+
+
+def nn_affs(data):
+    output = np.empty(shape=(2,)+data.shape[1:], dtype=data.dtype)
+    output[0] = (data[1] + data[2]) / 2.
+    output[1] = data[0]
+    return output


### PR DESCRIPTION
- Adds  a new function to the dask computation that allows for user-defined postprocessing (in analogy to preprocess). In particular, postprocessing can be used to handle the special case of nn affinities.

- Handles writing for multi channel outputs via `channel_order`

- Adds an example for predicting synapses on CREMI samples with thresholding and connected components as postprocessing  

